### PR TITLE
[FEATURE] Produce specific markdown for odt headers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.1.2
+  - 2.2.5
 notifications:
   email:
     - bostko@gmail.com

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,72 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.2)
+    diff-lcs (1.3)
+    ffi (1.9.25)
+    formatador (0.2.5)
+    guard (2.14.2)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
+    lumberjack (1.0.13)
+    method_source (0.9.0)
+    mini_portile2 (2.1.0)
+    nenv (0.3.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    notiffany (0.1.1)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    rake (10.4.2)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+    ruby_dep (1.5.0)
+    rubyzip (1.1.7)
+    shellany (0.0.1)
+    thor (0.20.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  guard-rspec
+  nokogiri (~> 1.6.3)
+  pry
+  rake (~> 10.4.2)
+  rspec (~> 3.1.0)
+  rspec-mocks (~> 3.1)
+  rubyzip (~> 1.1.6)
+
+BUNDLED WITH
+   1.16.4

--- a/lib/doc2text/docx/docx.rb
+++ b/lib/doc2text/docx/docx.rb
@@ -4,19 +4,19 @@ module Doc2Text
       class Document < DocumentFile
 
         def self.parse_and_save(input, output_filename)
-          odt = new input
+          docx = new input
           begin
-            odt.unpack
-            styles_xml_root = odt.parse_styles
+            docx.unpack
+            styles_xml_root = docx.parse_styles
             output = File.open output_filename, 'w'
             markdown = Markdown::DocxParser.new output, styles_xml_root
             begin
-              odt.parse markdown
+              docx.parse markdown
             ensure
               markdown.close
             end
           ensure
-            odt.clean
+            docx.clean
           end
         end
 

--- a/lib/doc2text/odt/odt.rb
+++ b/lib/doc2text/odt/odt.rb
@@ -1,5 +1,3 @@
-require 'zip'
-
 module Doc2Text
   module XmlBasedDocument
     module Odt

--- a/lib/doc2text/odt/odt_xml_namespaces.rb
+++ b/lib/doc2text/odt/odt_xml_namespaces.rb
@@ -146,7 +146,7 @@ module Doc2Text
             end
 
             def close
-              "\n"
+              "\n\n"
             end
           end
 

--- a/lib/doc2text/odt/odt_xml_namespaces.rb
+++ b/lib/doc2text/odt/odt_xml_namespaces.rb
@@ -123,6 +123,33 @@ module Doc2Text
                   style.attrs.index { |attr| attr.prefix == 'style' && attr.localname == 'name' && attr.value == style_name } }
             end
 
+          # http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#__RefHeading__1419212_253892949
+          class H < Node
+            include Text
+            def initialize(parent = nil, attrs = [], prefix = nil, name = nil, markdown_odt_parser = nil)
+              super parent, attrs, prefix, name, markdown_odt_parser
+              outline_level_index = attrs.index { |attr| attr.prefix == 'text' && attr.localname == 'outline-level' }
+              if outline_level_index and fetch_style?
+                @elem_outline_level = attrs[outline_level_index].value.to_i
+              else
+                @elem_outline_level = 0
+              end
+
+            end
+
+            def self.style_family
+              'paragraph'
+            end
+
+            def open
+              "\n#{'#' * @elem_outline_level} "
+            end
+
+            def close
+              "\n"
+            end
+          end
+
           # http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#__RefHeading__1419256_253892949
           class P < Node
             include Text

--- a/lib/doc2text/resolution.rb
+++ b/lib/doc2text/resolution.rb
@@ -3,7 +3,7 @@ module Doc2Text
     def self.parse_and_save(source, output)
       case File.extname source
         when '.docx'
-          Doc2Text::Docx::Document.parse_and_save source, output
+          Doc2Text::XmlBasedDocument::Docx::Document.parse_and_save source, output
         else
           Doc2Text::XmlBasedDocument::Odt::Document.parse_and_save source, output
       end

--- a/lib/doc2text/resolution.rb
+++ b/lib/doc2text/resolution.rb
@@ -5,7 +5,7 @@ module Doc2Text
         when '.docx'
           Doc2Text::Docx::Document.parse_and_save source, output
         else
-          Doc2Text::Odt::Document.parse_and_save source, output
+          Doc2Text::XmlBasedDocument::Odt::Document.parse_and_save source, output
       end
     end
   end

--- a/lib/doc2text/styles_parser.rb
+++ b/lib/doc2text/styles_parser.rb
@@ -5,9 +5,9 @@ module Doc2Text
 
       def start_element_namespace(name ,attrs = [], prefix = nil, uri = nil, ns = [])
         unless @xml_root
-          @xml_root = @current_node = Odt::XmlNodes::Node.create_node prefix, name, nil, attrs, self
+          @xml_root = @current_node = Doc2Text::XmlBasedDocument::Odt::XmlNodes::Node.create_node prefix, name, nil, attrs, self
         else
-          new_node = Odt::XmlNodes::Node.create_node prefix, name, @current_node, attrs, self
+          new_node = Doc2Text::XmlBasedDocument::Odt::XmlNodes::Node.create_node prefix, name, @current_node, attrs, self
           @current_node.children << new_node
           @current_node = new_node
         end

--- a/lib/doc2text/xml_based_document_file.rb
+++ b/lib/doc2text/xml_based_document_file.rb
@@ -1,3 +1,5 @@
+require 'zip'
+
 module Doc2Text
   module XmlBasedDocument
     class DocumentFile

--- a/spec/markdown_odt_parser_spec.rb
+++ b/spec/markdown_odt_parser_spec.rb
@@ -8,6 +8,26 @@ describe Doc2Text::Markdown::OdtParser do
     @parser = Nokogiri::XML::SAX::Parser.new(@markdown_odt_parser)
   end
 
+  it 'Parses headers' do
+    paragraphs = <<XML
+      <office:text>
+        <text:h text:outline-level="1">Title 1</text:h>
+        <text:h text:outline-level="2">Title 1.1</text:h>
+        <text:h text:outline-level="1">Title 2</text:h>
+      </office:text>
+XML
+
+    @parser.parse StringIO.new(paragraphs)
+    expect(@output.string.clone).to eq <<MARKDOWN
+
+# Title 1
+
+## Title 1.1
+
+# Title 2
+MARKDOWN
+  end
+
   it 'Parses paragraphs' do
     paragraphs = <<XML
       <office:text>

--- a/spec/markdown_odt_parser_spec.rb
+++ b/spec/markdown_odt_parser_spec.rb
@@ -22,9 +22,12 @@ XML
 
 # Title 1
 
+
 ## Title 1.1
 
+
 # Title 2
+
 MARKDOWN
   end
 


### PR DESCRIPTION
Right now, there is no support for odt <text:h> tags. This PR aims to solve this situation.