### PR TITLE
Update nokogiri to 1.11.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "nokogiri", ">= 1.10.5"
+gem "nokogiri", ">= 1.11.1"
 gem "rubyzip", ">= 2.0.0"
 gem 'rake', '~> 10.4.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,16 +24,18 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     lumberjack (1.0.13)
     method_source (0.9.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     nenv (0.3.0)
-    nokogiri (1.10.5)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    racc (1.5.2)
     rake (10.4.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -59,7 +61,7 @@ PLATFORMS
 
 DEPENDENCIES
   guard-rspec
-  nokogiri (>= 1.10.5)
+  nokogiri (>= 1.11.1)
   pry
   rake (~> 10.4.2)
   rspec (~> 3.1.0)

--- a/doc2text.gemspec
+++ b/doc2text.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary   = 'Translates odt to markdown'
   s.description = 'Parses odt to markdown'
 
-  s.add_runtime_dependency 'nokogiri', '~> 1.10.5'
+  s.add_runtime_dependency 'nokogiri', '~> 1.11.1'
   s.add_runtime_dependency 'rubyzip', '~> 2.0.0'
   s.files     = `git ls-files -- lib/* bin/doc2text`.split("\n")
   s.executables << 'doc2text'


### PR DESCRIPTION
Nokogiri version v1.11.0 fixes CVE-2020-26247 (https://github.com/advisories/GHSA-vr8q-g5c7-m54m)

https://github.com/sparklemotion/nokogiri/releases/tag/v1.11.0

This PR updates the Nokogiri dependency to the latest version available to fix the issue.