### PR TITLE
Fix `Doc2Text::Odt::Document.parse_and_save` when using tmp files as input 

### DIFF
--- a/lib/doc2text/xml_based_document_file.rb
+++ b/lib/doc2text/xml_based_document_file.rb
@@ -10,11 +10,10 @@ module Doc2Text
       def unpack
         Zip::File.open(@document_path) {
             |zip_file|
-          Dir.mkdir(extract_path)
           zip_file.each do |entry|
             zipped_file_extract_path = File.join extract_path, entry.name
             FileUtils.mkdir_p File.dirname(zipped_file_extract_path)
-            zip_file.extract entry, zipped_file_extract_path
+            zip_file.extract entry, zipped_file_extract_path, destination_directory: "/"
           end
         }
       end
@@ -41,7 +40,7 @@ module Doc2Text
       end
 
       def extract_path
-        File.join File.dirname(@document_path), ".#{File.basename(@document_path)}_#{extract_extension}"
+        @extract_path ||= Dir.mktmpdir(".#{File.basename(@document_path)}_#{extract_extension}")
       end
     end
   end

--- a/lib/doc2text/xml_based_document_file.rb
+++ b/lib/doc2text/xml_based_document_file.rb
@@ -1,4 +1,5 @@
 require 'zip'
+require 'tmpdir'
 
 module Doc2Text
   module XmlBasedDocument
@@ -13,7 +14,7 @@ module Doc2Text
           zip_file.each do |entry|
             zipped_file_extract_path = File.join extract_path, entry.name
             FileUtils.mkdir_p File.dirname(zipped_file_extract_path)
-            zip_file.extract entry, zipped_file_extract_path, destination_directory: "/"
+            zip_file.extract entry, entry.name, destination_directory: extract_path
           end
         }
       end

--- a/lib/doc2text/xml_based_document_file.rb
+++ b/lib/doc2text/xml_based_document_file.rb
@@ -9,11 +9,21 @@ module Doc2Text
       end
 
       def unpack
+        destination_root = Pathname.new(extract_path).realpath
+
         Zip::File.open(@document_path) {
             |zip_file|
           zip_file.each do |entry|
-            zipped_file_extract_path = File.join extract_path, entry.name
-            FileUtils.mkdir_p File.dirname(zipped_file_extract_path)
+            entry_path = Pathname.new(entry.name)
+
+            next if entry_path.absolute?
+            destination_path = destination_root.join(entry.name).cleanpath
+
+            unless destination_path.to_s.start_with?(destination_root.to_s + File::SEPARATOR)
+              raise "Unsafe zip entry: #{entry.name}"
+            end
+
+            FileUtils.mkdir_p(destination_path.dirname)
             zip_file.extract entry, entry.name, destination_directory: extract_path
           end
         }

--- a/spec/unpack_docx_spec.rb
+++ b/spec/unpack_docx_spec.rb
@@ -8,7 +8,7 @@ describe 'docx' do
     entries = Dir.glob "#{@odt.extract_path}/**/*"
     mandatory_files = %w([Content_Types].xml).map { |entry|
       File.join @odt.extract_path, entry }
-    expect(entries.to_set.subset? mandatory_files.to_set)
+    expect(mandatory_files.to_set).to be_subset(entries.to_set)
 
     @odt.clean
   end

--- a/spec/unpack_odt_spec.rb
+++ b/spec/unpack_odt_spec.rb
@@ -8,7 +8,7 @@ describe 'odt' do
     entries = Dir.glob "#{@odt.extract_path}/**/*"
     mandatory_files = %w(manifest.rdf content.xml settings.xml styles.xml META-INF META-INF/manifest.xml meta.xml mimetype).map { |entry|
       File.join @odt.extract_path, entry }
-    expect(entries.to_set.subset? mandatory_files.to_set)
+    expect(mandatory_files.to_set).to be_subset(entries.to_set)
 
     @odt.clean
   end
@@ -31,8 +31,9 @@ describe 'odt' do
       entries = Dir.glob "#{@odt.extract_path}/**/*"
       mandatory_files = %w(manifest.rdf content.xml settings.xml styles.xml META-INF META-INF/manifest.xml meta.xml mimetype).map { |entry|
         File.join @odt.extract_path, entry }
-      expect(entries.to_set.subset? mandatory_files.to_set)
+      expect(mandatory_files.to_set).to be_subset(entries.to_set)
 
+      tempfile.unlink
       @odt.clean
     end
   end

--- a/spec/unpack_odt_spec.rb
+++ b/spec/unpack_odt_spec.rb
@@ -17,4 +17,23 @@ describe 'odt' do
     rspec_extract_odt
     rspec_extract_odt
   end
+
+  context "when the odt is a temporary file" do
+    it "runs from a temp file" do
+      tempfile = Tempfile.new('text_styles.odt')
+      tempfile.write File.read(File.join 'spec', 'fixtures', 'text_styles.odt')
+      tempfile.rewind
+      tempfile.close
+
+      @odt = Doc2Text::Odt::Document.new tempfile
+      @odt.unpack
+
+      entries = Dir.glob "#{@odt.extract_path}/**/*"
+      mandatory_files = %w(manifest.rdf content.xml settings.xml styles.xml META-INF META-INF/manifest.xml meta.xml mimetype).map { |entry|
+        File.join @odt.extract_path, entry }
+      expect(entries.to_set.subset? mandatory_files.to_set)
+
+      @odt.clean
+    end
+  end
 end

--- a/spec/unpack_odt_spec.rb
+++ b/spec/unpack_odt_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'tempfile'
 
 describe 'odt' do
   def rspec_extract_odt


### PR DESCRIPTION
In decidim we have the following snippet: 
```
      def transform_to_md_file(doc_file)
        md_file = Tempfile.new
        Doc2Text::Odt::Document.parse_and_save doc_file, md_file
        md_file
      end
```
inside the `parse_and_save`, the input is `/tmp/doc-to-markdown-odt20260509-18225-lmbxu2`, and output_filename is `/tmp/20260509-18225-dtzzo3`.

Running the spec, on my end, i get an error like: 
```
  1) Decidim::Proposals::Admin::ImportParticipatoryText call when the form is valid with odt document behaves like import participatory_text succeeds broadcasts ok and creates the proposals
     Failure/Error: Doc2Text::Odt::Document.parse_and_save doc_file.path, md_file.path
     
     Errno::ENOENT:
       No such file or directory @ rb_sysopen - /home/myuser/Sites/decidim/develop/decidim-proposals/tmp/.doc-to-markdown-odt20260509-18225-lmbxu2_unpacked_odt/mimetype
     Shared Example Group: "import participatory_text succeeds" called from ./spec/commands/decidim/proposals/admin/import_participatory_text_spec.rb:93
     # ./lib/decidim/proposals/odt_to_markdown.rb:41:in 'Decidim::Proposals::OdtToMarkdown#transform_to_md_file'
     # ./lib/decidim/proposals/odt_to_markdown.rb:23:in 'Decidim::Proposals::OdtToMarkdown#to_md'
     # ./lib/decidim/proposals/doc_to_markdown.rb:42:in 'Decidim::Proposals::DocToMarkdown#to_md'
     # ./app/commands/decidim/proposals/admin/import_participatory_text.rb:48:in 'Decidim::Proposals::Admin::ImportParticipatoryText#parse_participatory_text_doc'
     # ./app/commands/decidim/proposals/admin/import_participatory_text.rb:27:in 'block in Decidim::Proposals::Admin::ImportParticipatoryText#call'
     # /home/alecslupu/Sites/decidim/develop/decidim-core/lib/decidim/command.rb:31:in 'Decidim::Command#transaction'
     # ./app/commands/decidim/proposals/admin/import_participatory_text.rb:25:in 'Decidim::Proposals::Admin::ImportParticipatoryText#call'
     # ./spec/commands/decidim/proposals/admin/import_participatory_text_spec.rb:43:in 'block (5 levels) in <module:Admin>'
     # ./spec/commands/decidim/proposals/admin/import_participatory_text_spec.rb:43:in 'block (4 levels) in <module:Admin>'
```

From the stack trace, I could identify that the spec (running with `--backtrace`) is actually failing in the `unpack` method of `Doc2Text::XmlBasedDocument::DocumentFile`. 

The line `zip_file.extract entry, zipped_file_extract_path` expects a third named argument `destination_directory:`, which has a default of `.`. This means that when you pass a file having the full path (ex a temp file), the destination_directory becomes `cwd` + original path, leading to strange path. 

I have managed to fix on my local, using the attached snippet.

